### PR TITLE
Fix compatibility issues

### DIFF
--- a/musl-glibc-symbol-abi.diff
+++ b/musl-glibc-symbol-abi.diff
@@ -1,15 +1,44 @@
+--- a/include/sys/random.h	2022-04-07 12:12:40.000000000 -0500
++++ b/include/sys/random.h	2022-09-14 21:17:51.000000000 -0500
+@@ -12,8 +12,23 @@
+ #define GRND_RANDOM	0x0002
+ #define GRND_INSECURE	0x0004
+ 
++#ifdef NO_GLIBC_ABI_COMPATIBLE
++
+ ssize_t getrandom(void *, size_t, unsigned);
+ 
++#else
++
++#include <sys/syscall.h>
++
++long syscall(long, ...);
++
++__attribute__((__weak__)) ssize_t getrandom(void *buf, size_t buflen, unsigned flags)
++{
++	return syscall(SYS_getrandom, buf, buflen, flags);
++}
++
++#endif
++
+ #ifdef __cplusplus
+ }
+ #endif
 --- a/include/sys/stat.h	2022-04-07 12:12:40.000000000 -0500
 +++ b/include/sys/stat.h	2022-09-02 11:57:58.000000000 -0500
-@@ -70,10 +70,29 @@
+@@ -70,10 +70,49 @@
  #define UTIME_NOW  0x3fffffff
  #define UTIME_OMIT 0x3ffffffe
  
 +#ifdef NO_GLIBC_ABI_COMPATIBLE
++
  int stat(const char *__restrict, struct stat *__restrict);
  int fstat(int, struct stat *);
  int lstat(const char *__restrict, struct stat *__restrict);
  int fstatat(int, const char *__restrict, struct stat *__restrict, int);
++
 +#else
++
 +int __xstat(int, const char *__restrict, struct stat *__restrict);
 +int __fxstat(int, int, struct stat *);
 +int __lxstat(int, const char *__restrict, struct stat *__restrict);
@@ -22,22 +51,42 @@
 +#define GLIBC_ABI_XSTAT_VERSION 1
 +#endif
 +
-+__attribute__((__weak__)) int stat(const char *__restrict path, struct stat *__restrict buf) { return __xstat(GLIBC_ABI_XSTAT_VERSION, path, buf); }
-+__attribute__((__weak__)) int fstat(int fd, struct stat *buf) { return __fxstat(GLIBC_ABI_XSTAT_VERSION, fd, buf); }
-+__attribute__((__weak__)) int lstat(const char *__restrict path, struct stat *__restrict buf) { return __lxstat(GLIBC_ABI_XSTAT_VERSION, path, buf); }
-+__attribute__((__weak__)) int fstatat(int fd, const char *__restrict path, struct stat *__restrict buf, int flag) { return __fxstatat(GLIBC_ABI_XSTAT_VERSION, fd, path, buf, flag); }
++__attribute__((__weak__)) int stat(const char *__restrict path, struct stat *__restrict buf)
++{
++	return __xstat(GLIBC_ABI_XSTAT_VERSION, path, buf);
++}
++
++__attribute__((__weak__)) int fstat(int fd, struct stat *buf)
++{
++	return __fxstat(GLIBC_ABI_XSTAT_VERSION, fd, buf);
++}
++
++__attribute__((__weak__)) int lstat(const char *__restrict path, struct stat *__restrict buf)
++{
++	return __lxstat(GLIBC_ABI_XSTAT_VERSION, path, buf);
++}
++
++__attribute__((__weak__)) int fstatat(int fd, const char *__restrict path, struct stat *__restrict buf, int flag)
++{
++	return __fxstatat(GLIBC_ABI_XSTAT_VERSION, fd, path, buf, flag);
++}
++
 +#endif
++
  int chmod(const char *, mode_t);
  int fchmod(int, mode_t);
  int fchmodat(int, const char *, mode_t, int);
-@@ -84,8 +103,23 @@
+@@ -84,8 +123,34 @@
  int mkfifoat(int, const char *, mode_t);
  
  #if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
 +#ifdef NO_GLIBC_ABI_COMPATIBLE
++
  int mknod(const char *, mode_t, dev_t);
  int mknodat(int, const char *, mode_t, dev_t);
++
 +#else
++
 +int __xmknod(int, const char *, mode_t, dev_t*);
 +int __xmknodat(int, int, const char *, mode_t, dev_t*);
 +
@@ -48,9 +97,68 @@
 +#define GLIBC_ABI_XMKNOD_VERSION 1
 +#endif
 +
-+__attribute__((__weak__)) int mknod(const char *path, mode_t mode, dev_t dev) { return __xmknod(GLIBC_ABI_XMKNOD_VERSION, path, mode, &dev); }
-+__attribute__((__weak__)) int mknodat(int fd, const char *path, mode_t mode, dev_t dev) { return __xmknodat(GLIBC_ABI_XMKNOD_VERSION, fd, path, mode, &dev); }
++__attribute__((__weak__)) int mknod(const char *path, mode_t mode, dev_t dev)
++{
++	return __xmknod(GLIBC_ABI_XMKNOD_VERSION, path, mode, &dev);
++}
++
++__attribute__((__weak__)) int mknodat(int fd, const char *path, mode_t mode, dev_t dev)
++{
++	return __xmknodat(GLIBC_ABI_XMKNOD_VERSION, fd, path, mode, &dev);
++}
++
 +#endif
  #endif
  
  int futimens(int, const struct timespec [2]);
+--- a/include/unistd.h	2022-04-07 12:12:40.000000000 -0500
++++ b/include/unistd.h	2022-09-14 21:37:17.000000000 -0500
+@@ -180,7 +180,48 @@
+ long syscall(long, ...);
+ int execvpe(const char *, char *const [], char *const []);
+ int issetugid(void);
++
++#ifdef NO_GLIBC_ABI_COMPATIBLE
++
+ int getentropy(void *, size_t);
++
++#else
++
++#include <errno.h>
++#include <sys/syscall.h>
++
++int pthread_setcancelstate(int, int *);
++
++__attribute__((__weak__)) int getentropy(void *buffer, size_t len)
++{
++	int cs, ret = 0;
++	char *pos = (char *)buffer;
++
++	if (len > 256) {
++		errno = EIO;
++		return -1;
++	}
++
++	pthread_setcancelstate(1 /* PTHREAD_CANCEL_DISABLE */, &cs);
++
++	while (len) {
++		ret = (int)syscall(SYS_getrandom, pos, len, 0);
++		if (ret < 0) {
++			if (errno == EINTR) continue;
++			else break;
++		}
++		pos += ret;
++		len -= ret;
++		ret = 0;
++	}
++
++	pthread_setcancelstate(cs, 0);
++
++	return ret;
++}
++
++#endif
++
+ extern int optreset;
+ #endif
+ 


### PR DESCRIPTION
Adds `getentropy()` and `getrandom()` as weak symbols.